### PR TITLE
Trigger now uses self.snapshot instead of NEW when referencing the pk of the model

### DIFF
--- a/pghistory/trigger.py
+++ b/pghistory/trigger.py
@@ -49,7 +49,7 @@ class Event(pgtrigger.Trigger):
         if hasattr(self.event_model, 'pgh_obj'):
             fields[
                 'pgh_obj_id'
-            ] = f'NEW."{_get_pgh_obj_pk_col(self.event_model)}"'
+            ] = f'{self.snapshot}."{_get_pgh_obj_pk_col(self.event_model)}"'
 
         if hasattr(self.event_model, 'pgh_context'):
             fields['pgh_context_id'] = '_pgh_attach_context()'


### PR DESCRIPTION
When using the delete trigger, NEW is None and create an IntegrityError on the database.
Using the correct "snapshot" (NEW or OLD) should fix this (after launching the migrate command).
Fixes #9.