### PR TITLE
Adding support for Django 4.0

### DIFF
--- a/pghistory/models.py
+++ b/pghistory/models.py
@@ -16,7 +16,9 @@ import pghistory.constants
 import pghistory.trigger
 
 # Django>=3.1 changes the location of JSONField
-if django.VERSION[0] >= 3 and django.VERSION[1] >= 1:
+if django.VERSION[0] > 4:
+    from django.db.models import JSONField
+elif django.VERSION[0] >= 3 and django.VERSION[1] >= 1:
     from django.db.models import JSONField
 else:
     from django.contrib.postgres.fields import JSONField

--- a/pghistory/models.py
+++ b/pghistory/models.py
@@ -16,7 +16,7 @@ import pghistory.constants
 import pghistory.trigger
 
 # Django>=3.1 changes the location of JSONField
-if django.VERSION[0] > 4:
+if django.VERSION[0] > 3:
     from django.db.models import JSONField
 elif django.VERSION[0] >= 3 and django.VERSION[1] >= 1:
     from django.db.models import JSONField

--- a/pghistory/trigger.py
+++ b/pghistory/trigger.py
@@ -49,8 +49,7 @@ class Event(pgtrigger.Trigger):
         if hasattr(self.event_model, 'pgh_obj'):
             fields[
                 'pgh_obj_id'
-            ] = f'NEW."{_get_pgh_obj_pk_col(self.event_model)}"'
-
+            ] = f'{self.snapshot}."{_get_pgh_obj_pk_col(self.event_model)}"'
         if hasattr(self.event_model, 'pgh_context'):
             fields['pgh_context_id'] = '_pgh_attach_context()'
 


### PR DESCRIPTION
Adding support for Django 4.0

ERRORS:
pghistory.AggregateEvent.pgh_data: (fields.E904) django.contrib.postgres.fields.JSONField is removed except for support in historical migrations.
        HINT: Use django.db.models.JSONField instead.
pghistory.AggregateEvent.pgh_diff: (fields.E904) django.contrib.postgres.fields.JSONField is removed except for support in historical migrations.
        HINT: Use django.db.models.JSONField instead.
pghistory.Context.metadata: (fields.E904) django.contrib.postgres.fields.JSONField is removed except for support in historical migrations.
        HINT: Use django.db.models.JSONField instead.
