### PR TITLE
Add support for delete requests in pghistory middleware

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -83,5 +83,6 @@ Primary Authors
 Other Contributors
 ==================
 
+- @shivananda-sahu
 - @asucrews
 - @Azurency

--- a/pghistory/middleware.py
+++ b/pghistory/middleware.py
@@ -28,7 +28,7 @@ def HistoryMiddleware(get_response):
     """
 
     def middleware(request):
-        if request.method in ('POST', 'PUT', 'PATCH'):
+        if request.method in ('POST', 'PUT', 'PATCH', 'DELETE'):
             with pghistory.context(
                 user=request.user.id if hasattr(request, 'user') else None,
                 url=request.path,

--- a/pghistory/tests/test_middleware.py
+++ b/pghistory/tests/test_middleware.py
@@ -43,7 +43,30 @@ def test_middleware(rf, mocker):
     assert resp.metadata == {'url': '/post/url/', 'user': None}
 
     # Authenticated users will be tracked
+    mock_user_id = 3
+    mock_user = mocker.Mock(id=mock_user_id)
     request = rf.post('/post/url2/')
-    request.user = mocker.Mock(id=3)
+    request.user = mock_user
     resp = pghistory.middleware.HistoryMiddleware(get_response)(request)
-    assert resp.metadata == {'url': '/post/url2/', 'user': 3}
+    assert resp.metadata == {'url': '/post/url2/', 'user': mock_user_id}
+
+    # PATCH requests initiate the tracker
+    patch_url = '/patch/url/'
+    request = rf.patch(patch_url)
+    request.user = mock_user
+    resp = pghistory.middleware.HistoryMiddleware(get_response)(request)
+    assert resp.metadata == {'url': patch_url, 'user': mock_user_id}
+
+    # PUT requests initiate the tracker
+    put_url = '/put/url/'
+    request = rf.put(put_url)
+    request.user = mock_user
+    resp = pghistory.middleware.HistoryMiddleware(get_response)(request)
+    assert resp.metadata == {'url': put_url, 'user': mock_user_id}
+
+    # DELETE requests initiate the tracker
+    delete_url = '/delete/url/'
+    request = rf.delete(delete_url)
+    request.user = mock_user
+    resp = pghistory.middleware.HistoryMiddleware(get_response)(request)
+    assert resp.metadata == {'url': delete_url, 'user': mock_user_id}


### PR DESCRIPTION
Currently the middleware adds a context for POST, PUT, and PATCH requests. This leaves out DELETE requests as the only ones that can affect a model without a context. Updating middleware to add a context for DELETE requests along with POST, PUT and PATCH.

Type: feature