### PR TITLE
Fixed bug in BeforeDelete event

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -79,3 +79,9 @@ Primary Authors
 ===============
 
 - @wesleykendall (Wes Kendall)
+
+Other Contributors
+==================
+
+- @asucrews
+- @Azurency

--- a/pghistory/tests/models.py
+++ b/pghistory/tests/models.py
@@ -104,6 +104,7 @@ class CustomSnapshotModel(
     pghistory.Event('manual_event'),
     pghistory.AfterInsert('model.create'),
     pghistory.BeforeUpdate('before_update'),
+    pghistory.BeforeDelete('before_delete'),
     pghistory.AfterUpdate(
         'after_update',
         condition=pgtrigger.Q(old__dt_field__df=pgtrigger.F('new__dt_field')),

--- a/pghistory/tests/test_core.py
+++ b/pghistory/tests/test_core.py
@@ -222,6 +222,25 @@ def test_events_on_event_model(mocker):
         }
     ]
 
+    # Verify a "before_delete" is fired
+    m_id = m.id
+    dt_field = m.dt_field
+    m.delete()
+    assert list(
+        test_models.EventModelEvent.objects.filter(pgh_label='before_delete').values()
+    ) == [
+        {
+            'pgh_created_at': mocker.ANY,
+            'dt_field': dt_field,
+            'pgh_id': mocker.ANY,
+            'pgh_label': 'before_delete',
+            'int_field': orig_int,
+            'pgh_obj_id': m_id,
+            'pgh_context_id': None,
+            'id': m_id,
+        },
+    ]
+
 
 @pytest.mark.django_db
 def test_dt_field_snapshot_tracking(mocker):

--- a/pghistory/trigger.py
+++ b/pghistory/trigger.py
@@ -45,7 +45,7 @@ class Event(pgtrigger.Trigger):
         fields['pgh_label'] = f"'{self.label}'"
 
         if hasattr(self.event_model, 'pgh_obj'):
-            fields['pgh_obj_id'] = f'NEW."{_get_pgh_obj_pk_col(self.event_model)}"'
+            fields['pgh_obj_id'] = f'{self.snapshot}."{_get_pgh_obj_pk_col(self.event_model)}"'
 
         if hasattr(self.event_model, 'pgh_context'):
             fields['pgh_context_id'] = '_pgh_attach_context()'


### PR DESCRIPTION
The BeforeDelete event was referencing the wrong trigger value (NEW).
Code was updated to reference the proper OLD row for this event,
and a failing test case was added.

Type: bug