### PR TITLE
Add support for GET requests in pghistory middleware

### DIFF
--- a/pghistory/middleware.py
+++ b/pghistory/middleware.py
@@ -28,7 +28,7 @@ def HistoryMiddleware(get_response):
     """
 
     def middleware(request):
-        if request.method in ('POST', 'PUT', 'PATCH', 'DELETE'):
+        if request.method in ('GET', 'POST', 'PUT', 'PATCH', 'DELETE'):
             with pghistory.context(
                 user=request.user.id if hasattr(request, 'user') else None,
                 url=request.path,


### PR DESCRIPTION
Currently the middleware adds a context for POST, PUT, PATCH and DELETE requests. Updating middleware to add a context for GET requests along with POST, PUT, PATCH and DELETE.

Type: feature

Additional details:

Here's a sample workflow where the context if of importance during GET requests.

- When a `GET` request goes via the auth workflow - a [successful login triggers the user_logged_in signal ](https://github.com/django/django/blob/main/django/contrib/auth/__init__.py#L144) of the user model. 
- This signal is used by django to [update the `last_login_time` attribute in the User model](https://github.com/django/django/blob/main/django%2Fcontrib%2Fauth%2Fmodels.py#L17-L23)