### PR TITLE
Use `pk` instead of `id` to get the user's primary key

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -88,3 +88,4 @@ Other Contributors
 - @Azurency
 - @dracos
 - @adamchainz
+- @eeriksp

--- a/pghistory/middleware.py
+++ b/pghistory/middleware.py
@@ -30,7 +30,7 @@ def HistoryMiddleware(get_response):
     def middleware(request):
         if request.method in ('GET', 'POST', 'PUT', 'PATCH', 'DELETE'):
             with pghistory.context(
-                user=request.user.id if hasattr(request, 'user') else None,
+                user=request.user.pk if hasattr(request, 'user') else None,
                 url=request.path,
             ):
                 if isinstance(request, DjangoWSGIRequest):  # pragma: no branch

--- a/pghistory/tests/test_middleware.py
+++ b/pghistory/tests/test_middleware.py
@@ -44,7 +44,7 @@ def test_middleware(rf, mocker):
 
     # Authenticated users will be tracked
     mock_user_id = 3
-    mock_user = mocker.Mock(id=mock_user_id)
+    mock_user = mocker.Mock(pk=mock_user_id)
     request = rf.post('/post/url2/')
     request.user = mock_user
     resp = pghistory.middleware.HistoryMiddleware(get_response)(request)


### PR DESCRIPTION
When the project has overridden the `User` model, they might use some other field as the primary key.
In this case there is no `id` field and the code will fail with `AttributeError: 'User' object has no attribute 'id'`.

Using the `pk` field instead will solve the issue since it will automatically point to the real primary key field.