### PR TITLE
Remove the PyTypeChecker warning

### DIFF
--- a/pghistory/runtime.py
+++ b/pghistory/runtime.py
@@ -71,7 +71,7 @@ class context(contextlib.ContextDecorator):
     be ignored.
 
     Args:
-        metadata (dict): Metadata that should be attached to the tracking
+        **metadata: Metadata that should be attached to the tracking
             context
 
     Example:


### PR DESCRIPTION
Remove the PyTypeChecker warning by using the proper parameter name (kwargs) in the context init function
Type: trivial