### PR TITLE
Fix SQL injection vector

### DIFF
--- a/pghistory/runtime.py
+++ b/pghistory/runtime.py
@@ -39,14 +39,10 @@ def _inject_history_context(execute, sql, params, many, context):
     if not cursor.name and not _is_concurrent_statement(sql):
         # Metadata is stored as a serialized JSON string with escaped
         # single quotes
-        metadata_str = json.dumps(_tracker.value.metadata, cls=config.json_encoder()).replace(
-            "'", "''"
-        )
+        metadata_str = json.dumps(_tracker.value.metadata, cls=config.json_encoder())
 
-        sql = (
-            f"SET LOCAL pghistory.context_id='{_tracker.value.id}';"
-            f"SET LOCAL pghistory.context_metadata='{metadata_str}';"
-        ) + sql
+        sql = f"SET LOCAL pghistory.context_id=%s; SET LOCAL pghistory.context_metadata=%s;{sql}"
+        params = [str(_tracker.value.id), metadata_str, *(params or ())]
 
     return execute(sql, params, many, context)
 

--- a/pghistory/tests/test_tracking.py
+++ b/pghistory/tests/test_tracking.py
@@ -102,12 +102,28 @@ def test_track_context_metadata_single_quote(mocker):
         # attach the current context
         ddf.G("tests.EventModel")
 
-        ctx1 = pghistory.models.Context.objects.get()
-        assert ctx1.id == ctx.id
-        assert ctx1.metadata == {
-            "key1": "can't",
-            "key2": "''quoted''",
-        }
+    ctx1 = pghistory.models.Context.objects.get()
+    assert ctx1.id == ctx.id
+    assert ctx1.metadata == {
+        "key1": "can't",
+        "key2": "''quoted''",
+    }
+
+
+@pytest.mark.django_db
+def test_track_context_metadata_percent(mocker):
+    """
+    Verifies that context metadata with single quotes is properly
+    escaped
+    """
+    with pghistory.context(key="%s") as ctx:
+        # Creating the EventModel will trigger an event, which will
+        # attach the current context
+        ddf.G("tests.EventModel")
+
+    ctx1 = pghistory.models.Context.objects.get()
+    assert ctx1.id == ctx.id
+    assert ctx1.metadata == {"key": "%s"}
 
 
 @pytest.mark.django_db


### PR DESCRIPTION
Previously data passed to `SET LOCAL` statements was directly added into the SQL. This could lead to SQL injection because pscyopg2's escaping would fail. The fix is to pass the data through `params` in order to get it escaped.

This problem arose a client project where a botted URL with an encoded HTTP newline, `%0d%0a`, was added to the context. Because those % symbols mean "insert parameter here" to psycopg2, the `execute()` call crashed with `IndexError: tuple index out of range`.

So %'s in context vars could cause a crash like that, perhaps a DoS vector. But I don't think it's exploitable to run arbitrary SQL, given the JSON string escaping.