### PR TITLE
Correct type hint of def track(obj_field=)

### DIFF
--- a/pghistory/core.py
+++ b/pghistory/core.py
@@ -485,7 +485,7 @@ def track(
     *trackers: Tracker,
     fields: Union[List[str], None] = None,
     exclude: Union[List[str], None] = None,
-    obj_field: "ObjForeignKey" = constants.UNSET,
+    obj_field: Union["ObjForeignKey", None] = constants.UNSET,
     context_field: Union["ContextForeignKey", "ContextJSONField"] = constants.UNSET,
     context_id_field: "ContextUUIDField" = constants.UNSET,
     append_only: bool = constants.UNSET,


### PR DESCRIPTION
When I upgraded pghistory, PyCharm showed me a type error that None is not expected, when it  actually is one of the allowed types. I can surpress this inspection for the entire class, but that is overkill. A correct type hint would be preferable, since None is a valid value and necessary for M2M table add/remove tracking.