### PR TITLE
Update event_tracking.md in line with changes in v3

### DIFF
--- a/docs/event_tracking.md
+++ b/docs/event_tracking.md
@@ -334,8 +334,8 @@ from django.contrib.auth.models import User
 import pghistory
 
 @pghistory.track(
-    pghistory.AfterInsert("group.add"),
-    pghistory.BeforeDelete("group.remove"),
+    pghistory.InsertEvent("group.add"),
+    pghistory.DeleteEvent("group.remove"),
     obj_field=None,
 )
 class UserGroups(User.groups.through):


### PR DESCRIPTION
I spent a while wondering why 'AfterInsert' wouldn't work as described in the docs - this change updates the relevant section docs to reflect the changes with v3.