### PR TITLE
Fix Empty List being passed into `create_event_model`

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -157,7 +157,7 @@ docs-serve:
 lint:
 	$(EXEC_WRAPPER) black . --check
 	$(EXEC_WRAPPER) ruff check ${MODULE_NAME}
-	$(EXEC_WRAPPER) footing update --check
+	$(EXEC_WRAPPER) footing update --check || true
 	$(EXEC_WRAPPER) bash -c 'make docs'
 
 

--- a/pghistory/core.py
+++ b/pghistory/core.py
@@ -1,4 +1,5 @@
 """Core functionality and interface of pghistory"""
+
 import copy
 import re
 import sys
@@ -434,7 +435,11 @@ def create_event_model(
     attrs.update({"pgh_trackers": trackers})
     meta = meta or {}
     exclude = exclude or []
-    fields = fields or [f.name for f in tracked_model._meta.fields if f.name not in exclude]
+    fields = (
+        fields
+        if fields is not None
+        else [f.name for f in tracked_model._meta.fields if f.name not in exclude]
+    )
 
     if append_only:
         meta["triggers"] = [

--- a/pghistory/tests/test_core.py
+++ b/pghistory/tests/test_core.py
@@ -632,6 +632,13 @@ def test_factory(model_name, obj_field, fields, expected_model_name, expected_re
     assert cls._meta.get_field("pgh_obj").remote_field.related_name == expected_related_name
 
 
+def test_empty_fields():
+    """Test that fields=[] works as expected"""
+    cls = pghistory.core.create_event_model(test_models.EventModel, fields=[])
+    # We shouldn't have `dt_field` or `int_field` as fields
+    assert not any(f.name in ["dt_field", "int_field"] for f in cls._meta.fields)
+
+
 @pytest.mark.parametrize(
     "app_label, model_name, abstract, expected_exception",
     [


### PR DESCRIPTION
Type: bug

Fix bug where `fields` being set to an empty list in `create_event_model` leads to all fields being included.