### PR TITLE
Fix events queryset failing for custom model PKs

### DIFF
--- a/pghistory/tests/test_middleware.py
+++ b/pghistory/tests/test_middleware.py
@@ -25,7 +25,7 @@ def test_post(client):
     assert test_models.SnapshotModelSnapshot.objects.get().pgh_context.metadata["user"] == user.id
 
 
-def test_middleware(rf, mocker):
+def test_middleware(rf):
     """
     Verifies pghistory context is tracked during certain requests
     with middleware in pghistory.middleware
@@ -44,7 +44,7 @@ def test_middleware(rf, mocker):
 
     # Authenticated users will be tracked
     mock_user_id = 3
-    mock_user = mocker.Mock(pk=mock_user_id)
+    mock_user = User(pk=mock_user_id)
     request = rf.post("/post/url2/")
     request.user = mock_user
     resp = pghistory.middleware.HistoryMiddleware(get_response)(request)


### PR DESCRIPTION
If a tracked model has a custom private key field, which has a different database representation to the instance value, the queryset for `pghistory.models.Event` fails.

Closes: https://github.com/Opus10/django-pghistory/issues/126

Additionally, this fixes middleware to store prepared user PK value in the context.

Type: bug