### PR TITLE
(#75) Don't register trigger on non-Postgres databases

### DIFF
--- a/pghistory/migrations/0004_auto_20220906_1625.py
+++ b/pghistory/migrations/0004_auto_20220906_1625.py
@@ -6,7 +6,9 @@ from pghistory.models import Context
 
 
 def install_pgh_attach_context_func(apps, schema_editor):
-    Context.install_pgh_attach_context_func(using=schema_editor.connection.alias)
+    # skip creating stored function for non-postgres database
+    if schema_editor.connection.vendor.startswith("postgres"):
+        Context.install_pgh_attach_context_func(using=schema_editor.connection.alias)
 
 
 class Migration(migrations.Migration):


### PR DESCRIPTION
Ran into trouble with our tests, which use an in-memory SQLite database. The solution proposed in #75 fixes this and there doesn't seem to be any issues otherwise. Looks like a PR for it just hasn't been made yet but this should do it.