### PR TITLE
Fix `PGHISTORY_DEFAULT_TRACKERS` setting

### DIFF
--- a/pghistory/config.py
+++ b/pghistory/config.py
@@ -1,5 +1,6 @@
 """Core way to access configuration"""
 
+import copy
 from typing import TYPE_CHECKING, Any, Dict, List, Tuple, Union
 
 from django.apps import apps
@@ -25,7 +26,14 @@ def default_trackers() -> Union[Tuple["Tracker"], None]:
     Returns:
         Default pghistory trackers
     """
-    return getattr(settings, "PGHISTORY_DEFAULT_TRACKERS", None)
+    default_trackers = getattr(settings, "PGHISTORY_DEFAULT_TRACKERS", None)
+
+    # Copy the default trackers, otherwise we end up with the same instances used across
+    # all models which causes issues
+    if default_trackers:
+        default_trackers = copy.deepcopy(default_trackers)
+
+    return default_trackers
 
 
 def append_only() -> bool:

--- a/pghistory/tests/test_config.py
+++ b/pghistory/tests/test_config.py
@@ -1,6 +1,6 @@
 from django.db import models
 
-from pghistory import config, constants
+from pghistory import config, constants, core
 
 
 def test_admin_ordering(settings):
@@ -149,3 +149,20 @@ def test_foreign_key_field(settings):
         "related_name": "+",
         "db_constraint": True,
     }
+
+
+def test_default_trackers(settings):
+    assert config.default_trackers() is None
+
+    settings.PGHISTORY_DEFAULT_TRACKERS = [
+        core.InsertEvent(),
+        core.UpdateEvent(),
+        core.DeleteEvent(),
+    ]
+
+    for expected_tracker, tracker in zip(
+        settings.PGHISTORY_DEFAULT_TRACKERS, config.default_trackers()
+    ):
+        # Trackers should be the same type, but different instances due to copying
+        assert type(expected_tracker) == type(tracker)
+        assert expected_tracker is not tracker


### PR DESCRIPTION
## Summary

Using the `PGHISTORY_DEFAULT_TRACKERS` setting doesn't seem to actually work, as the provided `pghistory.Tracker` instances are re-used across multiple models.

It doesn't look like `pghistory.Tracker`s were designed to be re-used across multiple models, so for now I've opted to make `pghistory.config.default_trackers` copy them via `copy.deep_copy` to ensure we get new instances each time. This is of course based on the assumption that doing `copy.deep_copy(tracker)` is valid.

An alternative fix to this could be making `PGHISTORY_DEFAULT_TRACKERS` require a callable instead, so users could do:

```python
PGHISTORY_DEFAULT_TRACKERS = lambda: [InsertEvent(), UpdateEvent(), DeleteEvent()]
```

...but that didn't seem to follow any existing pattern, so I didn't go down that route.

If `pghistory.Tracker` _is_ actually designed to be re-used, then a proper fix for this might be completely different.

See: #110 for more details.

## Changes
- `pghistory.config.default_trackers` now uses `copy.deep_copy` on the default trackers if provided
- Adds short unit test confirming `copy.deep_copy` functionality
