### PR TITLE
Fixes `TypeError: startswith first arg must be bytes or a tuple of bytes, not str`

### DIFF
--- a/pghistory/runtime.py
+++ b/pghistory/runtime.py
@@ -28,7 +28,10 @@ def _is_concurrent_statement(sql):
     True if the sql statement is concurrent and cannot be ran in a transaction
     """
     sql = sql.strip().lower() if sql else ""
-    return sql.startswith("create") and "concurrently" in sql
+    if isinstance(sql, bytes):
+        return sql.startswith(b"create") and b"concurrently" in sql
+    else:
+        return sql.startswith("create") and "concurrently" in sql
 
 
 def _is_transaction_errored(cursor):
@@ -80,10 +83,14 @@ def _inject_history_context(execute, sql, params, many, context):
         # single quotes
         serialized_metadata = json.dumps(_tracker.value.metadata, cls=config.json_encoder())
 
-        sql = (
+        inject_sql = (
             "SELECT set_config('pghistory.context_id', %s, true), "
             "set_config('pghistory.context_metadata', %s, true); "
-        ) + sql
+        )
+        if isinstance(sql, bytes):
+            sql = inject_sql.encode("utf-8") + sql
+        else:
+            sql = inject_sql + sql
         params = [str(_tracker.value.id), serialized_metadata, *(params or ())]
 
     return _execute_wrapper(execute(sql, params, many, context))


### PR DESCRIPTION
This PR fixes `_is_concurrent_statement()` and `_inject_history_context()` when called via `psycopg2`'s `execute_values()` or any other context that provides SQL in `bytes` rather than as a `str`.
```
  File "/path/to/mycode.py", line 575, in my_function
    execute_values(
  File "/path/to/venv/python-3.10/lib/python3.10/site-packages/psycopg2/extras.py", line 1299, in execute_values
    cur.execute(b''.join(parts))
  File "/path/to/venv/python-3.10/lib/python3.10/site-packages/django/db/backends/utils.py", line 102, in execute
    return super().execute(sql, params)
  File "/path/to/venv/python-3.10/lib/python3.10/site-packages/django/db/backends/utils.py", line 67, in execute
    return self._execute_with_wrappers(
  File "/path/to/venv/python-3.10/lib/python3.10/site-packages/django/db/backends/utils.py", line 80, in _execute_with_wrappers
    return executor(sql, params, many, context)
  File "/path/to/venv/python-3.10/lib/python3.10/site-packages/pghistory/runtime.py", line 78, in _inject_history_context
    if _can_inject_variable(context["cursor"], sql):
  File "/path/to/venv/python-3.10/lib/python3.10/site-packages/pghistory/runtime.py", line 65, in _can_inject_variable
    and not _is_concurrent_statement(sql)
  File "/path/to/venv/python-3.10/lib/python3.10/site-packages/pghistory/runtime.py", line 31, in _is_concurrent_statement
    return sql.startswith("create") and "concurrently" in sql
TypeError: startswith first arg must be bytes or a tuple of bytes, not str
```