### PR TITLE
Add possibility to change the function used to populate `pgh_created_at` field

### DIFF
--- a/pghistory/config.py
+++ b/pghistory/config.py
@@ -180,6 +180,17 @@ def exclude_field_kwargs() -> Dict["Field", List[str]]:
     return exclude_field_kwargs
 
 
+def created_at_function() -> str:
+    """The default PostgreSQL function used to populate the "pgh_created_at" field.
+
+    Use `clock_timestamp()` to set the actual current time and not the time of the transaction.
+
+    Returns:
+        PostgreSQL function to be used as a default value for the "pgh_created_at" field.
+    """
+    return getattr(settings, "PGHISTORY_CREATED_AT_FUNCTION", "NOW()")
+
+
 def admin_ordering() -> List[str]:
     """The default ordering for the events admin.
 

--- a/pghistory/trigger.py
+++ b/pghistory/trigger.py
@@ -3,7 +3,7 @@ import re
 import pgtrigger
 from django.db import models
 
-from pghistory import utils
+from pghistory import config, utils
 
 
 def _get_pgh_obj_pk_col(history_model):
@@ -76,7 +76,7 @@ class Event(pgtrigger.Trigger):
             and f.name in tracked_model_fields
             and f.concrete
         }
-        fields["pgh_created_at"] = "NOW()"
+        fields["pgh_created_at"] = config.created_at_function()
         fields["pgh_label"] = f"'{self.label}'"
 
         if hasattr(self.event_model, "pgh_obj"):


### PR DESCRIPTION
Currently, the code uses `NOW()` PostgreSQL function to set the value for the `pgh_created_at` field.

`NOW()` returns the same timestamp within the transaction, i.e. it may insert multiple rows in a batch to one events table with the same `pgh_created_at` value.

Technically, it's preferable to use the `clock_timestamp()` function instead. This will make sure that the `pgh_created_at` values will always have a real timestamp.

As this is a breaking change, I suggest adding a configuration that would allow setting the default function used to populate `pgh_created_at` field.