### PR TITLE
Make context middleware extensible

### DIFF
--- a/docs/context.md
+++ b/docs/context.md
@@ -42,6 +42,18 @@ Since the middleware starts context collection at the beginning of the request, 
 
 Use `settings.PGHISTORY_MIDDLEWARE_METHODS` to configure the requests that are tracked. It defaults to `("GET", "POST", "PUT", "PATCH", "DELETE")`.
 
+Add more context to the middleware by overriding the middleware's `get_context` method. For example, here we add the IP address:
+
+```python
+import pghistory.middleware
+
+class HistoryMiddleware(pghistory.middleware.HistoryMiddleware):
+    def get_context(self, request):
+        return super().get_context(request) | {
+            "ip_address": request.META.get('REMOTE_ADDR', 'unknown'),
+        }
+```
+
 ## Management Commands
 
 To capture all events issued under a management command, instrument `manage.py` like so:

--- a/pghistory/middleware.py
+++ b/pghistory/middleware.py
@@ -55,7 +55,7 @@ class HistoryMiddleware:
             if hasattr(request, "user") and hasattr(request.user, "_meta")
             else None
         )
-        return {'user': user, 'url': request.path}
+        return {"user": user, "url": request.path}
 
     def __call__(self, request):
         if request.method in config.middleware_methods():


### PR DESCRIPTION
`pghistory.middleware.HistoryMiddleware` has been updates so that it's easier to extend. To add more tracked context, override `get_context` on the middleware object. An example was added to the docs for tracking user IP addresses