### PR TITLE
Clean up configuration section of docs, ensure all settings are documented

### DIFF
--- a/docs/module.md
+++ b/docs/module.md
@@ -1,4 +1,4 @@
-# Module
+# Reference
 
 ::: pghistory
 ::: pghistory.admin

--- a/docs/settings.md
+++ b/docs/settings.md
@@ -2,74 +2,90 @@
 
 Below are all settings for `django-pghistory`.
 
-## PGHISTORY_MIDDLEWARE_METHODS
+## Middlware and Context Tracking
+
+#### PGHISTORY_MIDDLEWARE_METHODS
 
 Set the HTTP methods tracked by the middleware.
 
-**Default** `("GET", "POST", "PUT", "PATCH", "DELETE")`
+*Default* `("GET", "POST", "PUT", "PATCH", "DELETE")`
 
-## PGHISTORY_JSON_ENCODER
+#### PGHISTORY_JSON_ENCODER
 
 The JSON encoder class or class path to use when serializing context.
 
-**Default** `"django.core.serializers.json.DjangoJSONEncoder"`
+*Default* `"django.core.serializers.json.DjangoJSONEncoder"`
 
-## PGHISTORY_INSTALL_CONTEXT_FUNC_ON_MIGRATE
+#### PGHISTORY_INSTALL_CONTEXT_FUNC_ON_MIGRATE
 
 Install the Postgres `_pgh_attach_context` function after migrations. Ensures pghistory context tracking works even without running migrations, typically for test suites.
 
-**Default** `False`
+*Default* `False`
 
-## PGHISTORY_CREATED_AT_FUNCTION
+## Event Models and Trackers
 
-Pghistory uses `NOW()` to determine the current time, which is the same timestamp for the entire transaction. Configure this setting to `CLOCK_TIMESTAMP()`, for example, if you'd like to use a different SQL function for determining the current time.
+#### PGHISTORY_APPEND_ONLY
 
-**Default** `"NOW()"`
+If event models should be append-only by default.
 
-## PGHISTORY_BASE_MODEL
+*Default* `False`
+
+#### PGHISTORY_BASE_MODEL
 
 The base model to use for event models.
 
-**Default** `pghistory.models.Event`
+*Default* `pghistory.models.Event`
 
-## PGHISTORY_FIELD
-
-The default configuration for fields in event models.
-
-**Default** `pghistory.Field()`
-
-## PGHISTORY_RELATED_FIELD
-
-The default configuration for related fields in event models.
-
-**Default** `pghistory.RelatedField()`
-
-## PGHISTORY_FOREIGN_KEY_FIELD
-
-The default configuration for foreign keys in event models.
-
-**Default** `pghistory.ForeignKey()`
-
-## PGHISTORY_CONTEXT_FIELD
+#### PGHISTORY_CONTEXT_FIELD
 
 The default configuration for the `pgh_context` field.
 
-**Default** `pghistory.ContextForeignKey()`
+*Default* `pghistory.ContextForeignKey()`
 
-## PGHISTORY_CONTEXT_ID_FIELD
+#### PGHISTORY_CONTEXT_ID_FIELD
 
 The default configuration for the `pgh_context_id` field when [pghistory.ContextJSONField][] is used for the `pgh_context` field.
 
-**Default** `pghistory.ContextUUIDField()`
+*Default* `pghistory.ContextUUIDField()`
 
-## PGHISTORY_OBJ_FIELD
+#### PGHISTORY_CREATED_AT_FUNCTION
+
+Pghistory uses `NOW()` to determine the current time, which is the same timestamp for the entire transaction. Configure this setting to `CLOCK_TIMESTAMP()`, for example, if you'd like to use a different SQL function for determining the current time.
+
+*Default* `"NOW()"`
+
+#### PGHISTORY_DEFAULT_TRACKERS
+
+The default trackers to use for event models.
+
+*Default* `(pghistory.InsertEvent(), pghistory.UpdateEvent())`
+
+#### PGHISTORY_FIELD
+
+The default configuration for fields in event models.
+
+*Default* `pghistory.Field()`
+
+#### PGHISTORY_FOREIGN_KEY_FIELD
+
+The default configuration for foreign keys in event models.
+
+*Default* `pghistory.ForeignKey()`
+
+#### PGHISTORY_OBJ_FIELD
 
 The default configuration for the `pgh_obj` field.
 
-**Default** `pghistory.ObjForeignKey()`
+*Default* `pghistory.ObjForeignKey()`
+
+#### PGHISTORY_RELATED_FIELD
+
+The default configuration for related fields in event models.
+
+*Default* `pghistory.RelatedField()`
 
 <a id="exclude_field_kwargs"></a>
-## PGHISTORY_EXCLUDE_FIELD_KWARGS
+#### PGHISTORY_EXCLUDE_FIELD_KWARGS
 
 When creating fields for the event model, new fields are supplied with argument overrides. Sometimes this can result in an incorrect keyword argument being provided to a field. For example, `primary_key` fails Django's check framework when passed to an `ImageField`.
 
@@ -77,48 +93,46 @@ Use this setting to ignore certain keyword arguments being passed to child field
 
 The setting is a dictionary where the key is the field class or a string to a class path, and the value is a list of arguments to ignore. For example, `{models.ImageField: ["primary_key"]}`.
 
-**Default** `{}`
+*Default* `{}`
 
 !!! note
 
     The primary key example for image fields is already handled and does not need to be configured.
 
-## PGHISTORY_ADMIN_ORDERING
+## Admin
 
-The default ordering for the `Events` admin.
-
-**Default** `"-pgh_created_at"`
-
-## PGHISTORY_ADMIN_MODEL
-
-The default model or model label for the `Events` admin.
-
-**Default** `"pghistory.Events"`
-
-## PGHISTORY_ADMIN_QUERYSET
-
-The default queryset for the `Events` admin. If set, `PGHISTORY_ADMIN_MODEL` will be ignored.
-
-**Default** Uses `PGHISTORY_ADMIN_MODEL` ordered by `PGHISTORY_ADMIN_ORDERING`.
-
-## PGHISTORY_ADMIN_CLASS
-
-The admin class to use. Must subclass [pghistory.admin.EventsAdmin][].
-
-**Default** `"pghistory.admin.EventsAdmin"`
-
-## PGHISTORY_ADMIN_ALL_EVENTS
+#### PGHISTORY_ADMIN_ALL_EVENTS
 
 `True` if all events should be able to be displayed in the default Django `Events` admin page without filtering.
 
-**Default** `True`
+*Default* `True`
 
-!!! note
+#### PGHISTORY_ADMIN_CLASS
 
-    This setting only works in Django 3.1 and above.
+The admin class to use. Must subclass [pghistory.admin.EventsAdmin][].
 
-## PGHISTORY_ADMIN_LIST_DISPLAY
+*Default* `"pghistory.admin.EventsAdmin"`
+
+#### PGHISTORY_ADMIN_MODEL
+
+The default model or model label for the `Events` admin.
+
+*Default* `"pghistory.Events"`
+
+#### PGHISTORY_ADMIN_ORDERING
+
+The default ordering for the `Events` admin.
+
+*Default* `"-pgh_created_at"`
+
+#### PGHISTORY_ADMIN_LIST_DISPLAY
 
 The default fields shown in the `Events` admin.
 
-**Default** `["pgh_created_at", "pgh_obj_model", "pgh_obj_id", "pgh_diff"]`. If `pghistory.MiddlewareEvents` is the event model, the "user" and "url" fields will be added.
+*Default* `["pgh_created_at", "pgh_obj_model", "pgh_obj_id", "pgh_diff"]`. If `pghistory.MiddlewareEvents` is the event model, the "user" and "url" fields will be added.
+
+#### PGHISTORY_ADMIN_QUERYSET
+
+The default queryset for the `Events` admin. If set, `PGHISTORY_ADMIN_MODEL` will be ignored.
+
+*Default* Uses `PGHISTORY_ADMIN_MODEL` ordered by `PGHISTORY_ADMIN_ORDERING`.

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -85,7 +85,7 @@ nav:
       - Basics: basics.md
       - Event Tracking: event_tracking.md
       - Collecting Context: context.md
-      - Configuring Event Models: event_models.md
+      - Event Models: event_models.md
       - Aggregating Events and Diffs: aggregating_events.md
       - Admin Integration: admin.md
       - Reverting Objects: reversion.md
@@ -96,6 +96,6 @@ nav:
       - Upgrading: upgrading.md
   - API:
       - Settings: settings.md
-      - Module: module.md
+      - Reference: module.md
       - Release Notes: release_notes.md
       - Contributing Guide: contributing.md


### PR DESCRIPTION
Some settings, such as `PGHISTORY_DEFAULT_TRACKERS`, were not documented. This PR also cleans up the configuration section