### PR TITLE
More accurate type hints

### DIFF
--- a/pghistory/config.py
+++ b/pghistory/config.py
@@ -1,7 +1,7 @@
 """Core way to access configuration"""
 
 import copy
-from typing import TYPE_CHECKING, Any, Dict, List, Tuple, Union
+from typing import TYPE_CHECKING, Any, Dict, List, Tuple, Type, Union
 
 from django.apps import apps
 from django.conf import settings
@@ -12,8 +12,7 @@ from pghistory import constants
 
 if TYPE_CHECKING:
     from django.core.serializers.json import DjangoJSONEncoder
-    from django.db.models import QuerySet
-    from django.db.models.base import ModelBase
+    from django.db.models import Model, QuerySet
 
     from pghistory.admin import EventsAdmin
     from pghistory.core import Tracker
@@ -47,7 +46,7 @@ def append_only() -> bool:
     return getattr(settings, "PGHISTORY_APPEND_ONLY", False)
 
 
-def middleware_methods() -> Tuple[str]:
+def middleware_methods() -> Tuple[str, ...]:
     """
     Methods tracked by the pghistory middleware.
 
@@ -86,7 +85,7 @@ def json_encoder() -> "DjangoJSONEncoder":
     return encoder
 
 
-def base_model() -> "ModelBase":
+def base_model() -> Type["Model"]:
     """The base model for event models.
 
     Returns:
@@ -224,7 +223,7 @@ def admin_ordering() -> List[str]:
     return ordering
 
 
-def admin_model() -> "ModelBase":
+def admin_model() -> Type["Model"]:
     """The default list display for the events admin.
 
     Returns:
@@ -244,7 +243,7 @@ def admin_queryset() -> "QuerySet":
     )
 
 
-def admin_class() -> "EventsAdmin":
+def admin_class() -> Type["EventsAdmin"]:
     """The admin class to use for the events admin.
 
     Returns:
@@ -315,15 +314,15 @@ class Field:
     def __init__(
         self,
         *,
-        primary_key: bool = constants.UNSET,
-        unique: bool = constants.UNSET,
-        blank: bool = constants.UNSET,
-        null: bool = constants.UNSET,
-        db_index: bool = constants.UNSET,
-        editable: bool = constants.UNSET,
-        unique_for_date: bool = constants.UNSET,
-        unique_for_month: bool = constants.UNSET,
-        unique_for_year: bool = constants.UNSET,
+        primary_key: Union[bool, constants.Unset, constants.Default] = constants.UNSET,
+        unique: Union[bool, constants.Unset, constants.Default] = constants.UNSET,
+        blank: Union[bool, constants.Unset, constants.Default] = constants.UNSET,
+        null: Union[bool, constants.Unset, constants.Default] = constants.UNSET,
+        db_index: Union[bool, constants.Unset, constants.Default] = constants.UNSET,
+        editable: Union[bool, constants.Unset, constants.Default] = constants.UNSET,
+        unique_for_date: Union[bool, None, constants.Unset, constants.Default] = constants.UNSET,
+        unique_for_month: Union[bool, None, constants.Unset, constants.Default] = constants.UNSET,
+        unique_for_year: Union[bool, None, constants.Unset, constants.Default] = constants.UNSET,
     ):
         self._kwargs = _get_kwargs(locals())
         self._finalized = False
@@ -367,8 +366,8 @@ class RelatedField(Field):
     def __init__(
         self,
         *,
-        related_name: str = constants.UNSET,
-        related_query_name: str = constants.UNSET,
+        related_name: Union[str, constants.Unset, constants.Default] = constants.UNSET,
+        related_query_name: Union[str, constants.Unset, constants.Default] = constants.UNSET,
         **kwargs: Any,
     ):
         super().__init__(**kwargs)
@@ -398,7 +397,7 @@ class ForeignKey(RelatedField):
         self,
         *,
         on_delete: Any = constants.UNSET,
-        db_constraint: bool = constants.UNSET,
+        db_constraint: Union[bool, constants.Unset, constants.Default] = constants.UNSET,
         **kwargs: Any,
     ):
         super().__init__(**kwargs)
@@ -423,10 +422,12 @@ class ContextForeignKey(ForeignKey):
     """
 
     def __init__(
-        self, *, null: bool = True, related_query_name: str = constants.DEFAULT, **kwargs: Any
+        self,
+        *,
+        null: bool = True,
+        related_query_name: Union[str, constants.Unset, constants.Default] = constants.UNSET,
+        **kwargs: Any,
     ):
-        # Note: We will be changing the default context field to have on_delete=PROTECT
-        # in version 3.
         super().__init__(null=null, related_query_name=related_query_name, **kwargs)
         self._kwargs.update(_get_kwargs(locals()))
 
@@ -466,8 +467,8 @@ class ObjForeignKey(ForeignKey):
     def __init__(
         self,
         *,
-        related_name: str = constants.DEFAULT,
-        related_query_name: str = constants.DEFAULT,
+        related_name: Union[str, constants.Unset, constants.Default] = constants.UNSET,
+        related_query_name: Union[str, constants.Unset, constants.Default] = constants.UNSET,
         **kwargs,
     ):
         # Note: We will be changing the default object field to nullable with on_delete=SET_NULL

--- a/pghistory/constants.py
+++ b/pghistory/constants.py
@@ -1,6 +1,17 @@
-DEFAULT = object()
+import enum
+
+
+class Default(enum.Enum):
+    token = 0
+
+
+class Unset(enum.Enum):
+    token = 0
+
+
+DEFAULT = Default.token
 """
 For setting a configuration value back to its default value
 """
 
-UNSET = object()
+UNSET = Unset.token

--- a/pghistory/core.py
+++ b/pghistory/core.py
@@ -3,7 +3,7 @@
 import copy
 import re
 import sys
-from typing import TYPE_CHECKING, Any, Dict, List, Type, Union
+from typing import TYPE_CHECKING, Any, Dict, List, Optional, Type, Union
 
 import pgtrigger
 import pgtrigger.core
@@ -46,7 +46,7 @@ _registered_trackers = {}
 class Tracker:
     """For tracking an event when a condition happens on a model."""
 
-    label: str = None
+    label: Optional[str] = None
 
     def __init__(self, label=None):
         self.label = label or self.label
@@ -81,19 +81,19 @@ class ManualEvent(Tracker):
 class RowEvent(Tracker):
     """For tracking an event automatically based on row-level changes."""
 
-    condition: Union[pgtrigger.Condition, None] = constants.UNSET
-    operation: pgtrigger.Operation = None
-    row: str = None
-    trigger_name: str = None
+    condition: Union[Optional[pgtrigger.Condition], constants.Unset] = constants.UNSET
+    operation: Optional[pgtrigger.Operation] = None
+    row: Optional[str] = None
+    trigger_name: Optional[str] = None
 
     def __init__(
         self,
-        label: str = None,
+        label: Optional[str] = None,
         *,
-        condition: Union[pgtrigger.Condition, None] = constants.UNSET,
-        operation: pgtrigger.Operation = None,
-        row: str = None,
-        trigger_name: str = None,
+        condition: Union[Optional[pgtrigger.Condition], constants.Unset] = constants.UNSET,
+        operation: Optional[pgtrigger.Operation] = None,
+        row: Optional[str] = None,
+        trigger_name: Optional[str] = None,
     ):
         super().__init__(label=label)
 
@@ -145,9 +145,9 @@ class InsertEvent(RowEvent):
     The default label used is "insert".
     """
 
-    label: str = "insert"
-    row: str = "NEW"
-    operation: pgtrigger.Operation = pgtrigger.Insert
+    label: Optional[str] = "insert"
+    row: Optional[str] = "NEW"
+    operation: Optional[pgtrigger.Operation] = pgtrigger.Insert
 
 
 class UpdateEvent(RowEvent):
@@ -163,9 +163,9 @@ class UpdateEvent(RowEvent):
     a condition, or the row to snapshot.
     """
 
-    label: str = "update"
-    row: str = "NEW"
-    operation: pgtrigger.Operation = pgtrigger.Update
+    label: Optional[str] = "update"
+    row: Optional[str] = "NEW"
+    operation: Optional[pgtrigger.Operation] = pgtrigger.Update
 
 
 class DeleteEvent(RowEvent):
@@ -174,9 +174,9 @@ class DeleteEvent(RowEvent):
     The default label used is "delete".
     """
 
-    label: str = "delete"
-    row: str = "OLD"
-    operation: pgtrigger.Operation = pgtrigger.Delete
+    label: Optional[str] = "delete"
+    row: Optional[str] = "OLD"
+    operation: Optional[pgtrigger.Operation] = pgtrigger.Delete
 
 
 def _pascalcase(string):
@@ -342,15 +342,17 @@ def create_event_model(
     *trackers: Tracker,
     fields: Union[List[str], None] = None,
     exclude: Union[List[str], None] = None,
-    obj_field: "ObjForeignKey" = constants.UNSET,
-    context_field: Union["ContextForeignKey", "ContextJSONField"] = constants.UNSET,
-    context_id_field: "ContextUUIDField" = constants.UNSET,
-    append_only: bool = constants.UNSET,
+    obj_field: Union["ObjForeignKey", constants.Unset] = constants.UNSET,
+    context_field: Union[
+        "ContextForeignKey", "ContextJSONField", constants.Unset
+    ] = constants.UNSET,
+    context_id_field: Union["ContextUUIDField", constants.Unset] = constants.UNSET,
+    append_only: Union[bool, constants.Unset] = constants.UNSET,
     model_name: Union[str, None] = None,
     app_label: Union[str, None] = None,
-    base_model: Type[models.Model] = None,
-    attrs: Dict[str, Any] = None,
-    meta: Dict[str, Any] = None,
+    base_model: Optional[Type[models.Model]] = None,
+    attrs: Optional[Dict[str, Any]] = None,
+    meta: Optional[Dict[str, Any]] = None,
     abstract: bool = True,
 ) -> Type[models.Model]:
     """
@@ -488,17 +490,19 @@ def ProxyField(proxy: str, field: Type[models.Field]):
 
 def track(
     *trackers: Tracker,
-    fields: Union[List[str], None] = None,
-    exclude: Union[List[str], None] = None,
-    obj_field: Union["ObjForeignKey", None] = constants.UNSET,
-    context_field: Union["ContextForeignKey", "ContextJSONField"] = constants.UNSET,
-    context_id_field: "ContextUUIDField" = constants.UNSET,
-    append_only: bool = constants.UNSET,
-    model_name: Union[str, None] = None,
-    app_label: Union[str, None] = None,
-    base_model: Type[models.Model] = None,
-    attrs: Dict[str, Any] = None,
-    meta: Dict[str, Any] = None,
+    fields: Optional[List[str]] = None,
+    exclude: Optional[List[str]] = None,
+    obj_field: Union[Optional["ObjForeignKey"], constants.Unset] = constants.UNSET,
+    context_field: Union[
+        "ContextForeignKey", "ContextJSONField", constants.Unset
+    ] = constants.UNSET,
+    context_id_field: Union["ContextUUIDField", constants.Unset] = constants.UNSET,
+    append_only: Union[bool, constants.Unset] = constants.UNSET,
+    model_name: Optional[str] = None,
+    app_label: Optional[str] = None,
+    base_model: Optional[Type[models.Model]] = None,
+    attrs: Optional[Dict[str, Any]] = None,
+    meta: Optional[Dict[str, Any]] = None,
 ):
     """
     A decorator for tracking events for a model.
@@ -649,9 +653,9 @@ def create_event(obj: models.Model, *, label: str, using: str = "default") -> mo
 
 
 def event_models(
-    models: List[Type[models.Model]] = None,
-    references_model: Type[models.Model] = None,
-    tracks_model: Type[models.Model] = None,
+    models: Optional[List[Type[models.Model]]] = None,
+    references_model: Optional[Type[models.Model]] = None,
+    tracks_model: Optional[Type[models.Model]] = None,
     include_missing_pgh_obj: bool = False,
 ) -> List[Type[models.Model]]:
     """


### PR DESCRIPTION
Some of the type hints for core functions were not correct, especially those that accept/return model types or sentinel values. Although there is some work to go for full type safety with pghistory, this should alleviate many common issues when using the core interface