### PR TITLE
Adjust guide on tracking management commands

### DIFF
--- a/docs/context.md
+++ b/docs/context.md
@@ -74,6 +74,7 @@ if __name__ == "__main__":
     if (
         len(sys.argv) > 1
         and not sys.argv[1].startswith("runserver")
+        and not sys.argv[1] == "migrate"
     ):
         # Group history context under the same management command if
         # we aren't running a server.
@@ -86,6 +87,10 @@ if __name__ == "__main__":
 ```
 
 Above we ignore tracking context for `runserver` commands. Otherwise every single change in a development session would be grouped under the same context.
+
+!!! note
+
+    We also ignore `migrate`. Some custom schema-altering SQL can disrupt pghistory's context tracking. See [Issue #109](https://github.com/Opus10/django-pghistory/issues/109) for more information.
 
 ## Celery Tasks
 


### PR DESCRIPTION
The context tracking guide's example on tracking management commands ignores `migrate`. Recent changes in Pghistory's context tracking add `%s` in the adjusted SQL. If any custom SQL has `%....s` in it without accompanying arguments, this creates a SQL execution error once the SQL is modified.

I made an issue to track this at https://github.com/Opus10/django-pghistory/issues/149

For now, I've updated the doc examples to not track `migrate` whenever tracking management commands. This resolves https://github.com/Opus10/django-pghistory/issues/109

