### PR TITLE
Ensure `pghistory.create_event` is compatible with denormalized context

### DIFF
--- a/pghistory/tests/test_models.py
+++ b/pghistory/tests/test_models.py
@@ -6,6 +6,7 @@ import pytest
 from django.core.management import call_command
 
 import pghistory.models
+import pghistory.runtime
 import pghistory.tests.models as test_models
 
 

--- a/pghistory/tests/test_models.py
+++ b/pghistory/tests/test_models.py
@@ -5,7 +5,6 @@ import django
 import pytest
 from django.core.management import call_command
 
-import pghistory.models
 import pghistory.runtime
 import pghistory.tests.models as test_models
 


### PR DESCRIPTION
`pghistory.create_event` now handles manual creation of events for trackers with denormalized or no context fields. Resolves #115 