### PR TITLE
Check that execute result is not `None` in psycopg3 when using context tracking

### DIFF
--- a/pghistory/runtime.py
+++ b/pghistory/runtime.py
@@ -70,7 +70,7 @@ def _can_inject_variable(cursor, sql):
 
 def _execute_wrapper(execute_result):
     if utils.psycopg_maj_version == 3:
-        while execute_result.nextset():
+        while execute_result is not None and execute_result.nextset():
             pass
     return execute_result
 


### PR DESCRIPTION
Resolves #117 

It's still unclear what situations result in a `None` execute result. For now doing the obvious fix. Can later add an appropriate failing test when reproduced